### PR TITLE
Add envsubst support to allow configuration with environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ RUN apk --no-cache add \
         nginx \
         runit \
         curl \
-
 # Bring in gettext so we can get `envsubst`, then throw
 # the rest away. To do this, we need to install `gettext`
 # then move `envsubst` out of the way so `gettext` can
@@ -95,4 +94,4 @@ ENV client_max_body_size=2M \
     memory_limit=128M \
     post_max_size=8M \
     upload_max_filesize=2M \
-    zlib.output_compression=Off
+    zlib.output_compression=On

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,29 @@ RUN apk --no-cache add \
         nginx \
         runit \
         curl \
+
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+    && apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/ \
+# Remove alpine cache
     && rm -rf /var/cache/apk/* \
-    # Remove default server definition
+# Remove default server definition
     && rm /etc/nginx/conf.d/default.conf \
-    # Make sure files/folders needed by the processes are accessable when they run under the nobody user
+# Make sure files/folders needed by the processes are accessable when they run under the nobody user
     && chown -R nobody.nobody /run \
     && chown -R nobody.nobody /var/lib/nginx \
     && chown -R nobody.nobody /var/log/nginx
@@ -64,3 +83,16 @@ CMD [ "/bin/docker-entrypoint.sh" ]
 
 # Configure a healthcheck to validate that everything is up&running
 HEALTHCHECK --timeout=10s CMD curl --silent --fail http://127.0.0.1:8080/fpm-ping
+
+ENV client_max_body_size=2M \
+    allow_url_fopen=On \
+    allow_url_include=Off \
+    display_errors=Off \
+    file_uploads=On \
+    max_execution_time=0 \
+    max_input_time=-1 \
+    max_input_vars=1000 \
+    memory_limit=128M \
+    post_max_size=8M \
+    upload_max_filesize=2M \
+    zlib.output_compression=Off

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Repository: https://github.com/erseco/alpine-php7-webserver
 
 
 * Built on the lightweight and secure Alpine Linux distribution
-* Very small Docker image size (+/-35MB)
+* Very small Docker image size (+/-25MB)
 * Uses PHP 7.3 for better performance, lower cpu usage & memory footprint
 * Optimized for 100 concurrent users
 * Optimized to only use resources when there's traffic (by using PHP-FPM's ondemand PM)
@@ -71,7 +71,7 @@ The following example shows how you can add a startup script. This script simply
 
 
 ## Configuration
-In [config/](config/) you'll find the default configuration files for Nginx, PHP and PHP-FPM.
+In [rootfs/etc/](rootfs/etc/) you'll find the default configuration files for Nginx, PHP and PHP-FPM.
 If you want to extend or customize that you can do so by mounting a configuration file in the correct folder;
 
 Nginx configuration:
@@ -88,6 +88,26 @@ PHP-FPM configuration:
 
 _Note; Because `-v` requires an absolute path I've added `pwd` in the example to return the absolute path to the current directory_
 
+## Environment variables
+
+You can define the next environment variables to change values from NGINX and PHP
+
+| Server | Variable Name           | Default | description                                                                                                                                                                                                                                            |
+|--------|-------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| NGINX  | client_max_body_size    | 2m      | Sets the maximum allowed size of the client request body, specified in the “Content-Length” request header field.                                                                                                                                      |
+| PHP7   | allow_url_fopen         | On      | This option enables the URL-aware fopen wrappers that enable accessing URL object like files. Default wrappers are provided for the access of remote files using the ftp or http protocol, some extensions like zlib may register additional wrappers. |
+| PHP7   | allow_url_include       | Off     | This option allows the use of URL-aware fopen wrappers with the following functions: include(), include_once(), require(), require_once().                                                                                                             |
+| PHP7   | display_errors          | Off     | This determines whether errors should be printed to the screen as part of the output or if they should be hidden from the user.                                                                                                                        |
+| PHP7   | file_uploads            | On      | Whether or not to allow HTTP file uploads.                                                                                                                                                                                                             |
+| PHP7   | max_execution_time      | 0       | This sets the maximum time in seconds a script is allowed to run before it is terminated by the parser. This helps prevent poorly written scripts from tying up the server. The default setting is 30.                                                 |
+| PHP7   | max_input_time          | -1      | This sets the maximum time in seconds a script is allowed to parse input data, like POST, GET and file uploads.                                                                                                                                        |
+| PHP7   | max_input_vars          | 1000    | This sets the maximum number of input variables allowed per request and can be used to deter denial of service attacks involving hash collisions on the input variable names.                                                                          |
+| PHP7   | memory_limit            | 128M    | This sets the maximum amount of memory in bytes that a script is allowed to allocate. This helps prevent poorly written scripts for eating up all available memory on a server. Note that to have no memory limit, set this directive to -1.           |
+| PHP7   | post_max_size           | 8M      | Sets max size of post data allowed. This setting also affects file upload. To upload large files, this value must be larger than upload_max_filesize. Generally speaking, memory_limit should be larger than post_max_size.                            |
+| PHP7   | upload_max_filesize     | 2M      | The maximum size of an uploaded file.                                                                                                                                                                                                                  |
+| PHP7   | zlib.output_compression | On      | Whether to transparently compress pages. If this option is set to "On" in php.ini or the Apache configuration, pages are compressed if the browser sends an "Accept-Encoding: gzip" or "deflate" header.                                               |
+
+
 
 ## Adding composer
 
@@ -95,10 +115,10 @@ If you need composer in your project, here's an easy way to add it;
 
 ```dockerfile
 FROM erseco/alpine-php7-webserver:latest
-
+USER root
 # Install composer from the official image
-COPY --from=composer /usr/bin/composer /usr/bin/composer
-
+RUN apk add --no-cache composer
+USER nobody
 # Run composer install to install the dependencies
 RUN composer install --optimize-autoloader --no-interaction --no-progress
 ```

--- a/rootfs/bin/docker-entrypoint.sh
+++ b/rootfs/bin/docker-entrypoint.sh
@@ -39,7 +39,7 @@ done
 echo "Finished startup scripts in /docker-entrypoint-init.d"
 
 echo "Starting runit..."
-exec env - PATH=$PATH runsvdir -P /etc/service &
+exec runsvdir -P /etc/service &
 
 RUNSVDIR=$!
 echo "Started runsvdir, PID is $RUNSVDIR"

--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -41,7 +41,7 @@ http {
         proxy_busy_buffers_size 256k;
 
         # Upload limit
-        client_max_body_size 50m;
+        client_max_body_size ${client_max_body_size};
         client_body_buffer_size 128k;
 
         root /var/www/html;

--- a/rootfs/etc/php7/conf.d/custom.ini
+++ b/rootfs/etc/php7/conf.d/custom.ini
@@ -1,6 +1,14 @@
 [Date]
 date.timezone="UTC"
 
-; Up the upload limit
-post_max_size = 50M
-upload_max_filesize = 50M
+allow_url_fopen = $allow_url_fopen
+allow_url_include= $allow_url_include
+display_errors= $display_errors
+file_uploads= $file_uploads
+max_execution_time= $max_execution_time
+max_input_time= $max_input_time
+max_input_vars= $max_input_vars
+memory_limit= $memory_limit
+post_max_size= $post_max_size
+upload_max_filesize= $upload_max_filesize
+zlib.output_compression= $zlib.output_compression

--- a/rootfs/etc/service/nginx/run
+++ b/rootfs/etc/service/nginx/run
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
-# pipe stderr to stdout and run nginx
+# Replace ENV vars in configuration files
+tmpfile=$(mktemp)
+cat /etc/nginx/nginx.conf | envsubst "$(env | cut -d= -f1 | sed -e 's/^/$/')" | tee "$tmpfile" > /dev/null
+mv "$tmpfile" /etc/nginx/nginx.conf
+
+# pipe stderr to stdout and run nginx omiting ENV vars to avoid security leaks
 exec 2>&1
-exec nginx -g 'daemon off;'
+exec env - PATH=$PATH nginx -g 'daemon off;'

--- a/rootfs/etc/service/php/run
+++ b/rootfs/etc/service/php/run
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
-# pipe stderr to stdout and run php-fpm
+# Replace ENV vars in configuration files
+tmpfile=$(mktemp)
+cat /etc/php7/conf.d/custom.ini | envsubst "$(env | cut -d= -f1 | sed -e 's/^/$/')" | tee "$tmpfile" > /dev/null
+mv "$tmpfile" /etc/php7/conf.d/custom.ini
+
+# pipe stderr to stdout and run php-fpm omiting ENV vars to avoid security leaks
 exec 2>&1
-exec php-fpm7 -F
+exec env - PATH=$PATH php-fpm7 -F


### PR DESCRIPTION
Add the `envsubst` from gettext package to allow the configuration via environment variables